### PR TITLE
Fix GitHub stats badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 
 <p align="center">
   <a href="https://github.com/Aravinda214">
-    <img align="center" src="https://github-readme-stats.vercel.app/api?username=Aravinda214&show_icons=true&hide_border=true&title_color=94b4a4&amp&icon_color=FFFFFF&amp&text_color=FFFFFF&amp&bg_color=000000&count_private=true&include_all_commits=true"/>
+    <img align="center" src="https://github-readme-stats.vercel.app/api?username=Aravinda214&show_icons=true&hide_border=true&title_color=94b4a4&icon_color=FFFFFF&text_color=FFFFFF&bg_color=000000&count_private=true&include_all_commits=true"/>
   </a>
 </p>
 </details>


### PR DESCRIPTION
## Summary
- fix malformed query parameters in the README GitHub stats badge

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6840dd00a3d0832fa5dee3cda9880bdb